### PR TITLE
Update doctest function signature, only require file name under test

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ import { doctest } from "https://deno.land/x/doctest@{VERSION}/mod.js";
 /**
  * A test
  */
-Deno.test("Tests", (t) => doctest(t, "hello.js"));
+Deno.test("Tests", doctest("hello.js"));
 ```
 
 Where {VERSION} should be substituted with the specific version you want to use.
 
 3. Run `deno test` and relax. Your code _and_ your examples are tested!
 
-```bash
+```
 $ deno test
 
   Tests
@@ -67,6 +67,237 @@ $ deno test
 Errors (both thrown Errors and rejected Promises), generator functions, and
 more. Examples are in [spec](spec). This also acts as the specification and test
 suite for `doctest`.
+
+### Running `doctest` tests
+
+```bash
+$ deno test -A
+running 2 tests from ./test.js
+Doctest ...
+  mod ... ignored (0ms)
+  lib.js ...
+    getTests ...
+      getTests([{
+  name: "Math.max",
+  location: {
+    filename: "file:///tmp/index.js",
+    line: 10,
+    col: 0
+  },
+  jsDoc: {
+    tags: [{
+      kind: "example",
+      doc: "Math.max(1, 3)\n//=> 3"
+    }]
+  }
+}])
+//=> [
+  {
+    functionName: "Math.max",
+    location: {
+      filename: "file:///tmp/index.js",
+      line: 10,
+      col: 0
+    },
+    examples: [{
+      test: "Math.max(1, 3)",
+      example: "Math.max(1, 3)\n//=> 3",
+      expected: "3"
+    }]
+  }
+] ... ok (20ms)
+      getTests([{
+  kind: "class",
+  classDef: {
+    methods: [{
+      jsDoc: {
+        tags: [{
+          kind: "example",
+          doc: "add(1, 2)\n//=> 3"
+        }]
+      },
+      name: "add",
+      location: {
+        filename: "file:///tmp/index.js",
+        line: 17,
+        col: 4711
+      }
+    }]
+  }
+}])
+//=> [
+  {
+    functionName: "add",
+    location: {
+      filename: "file:///tmp/index.js",
+      line: 17,
+      col: 4711
+    },
+    examples: [{
+      test: "add(1, 2)",
+      example: "add(1, 2)\n//=> 3",
+      expected: "3"
+    }]
+  }
+] ... ok (12ms)
+    getTests ... ok (22ms)
+  lib.js ... ok (30ms)
+Doctest ... ok (514ms)
+Specification ...
+  Functions returning a Promise can be tested like a regular function ...
+    spec/returns-promise.js ...
+      returnsPromise ...
+        returnsPromise(17)
+//=> 17 ... ok (30ms)
+        returnsPromise(17)
+//=> Promise.resolve(17) ... ok (22ms)
+      returnsPromise ... ok (30ms)
+      rejectsPromise ...
+        rejectsPromise(17)
+//=> throw new Error(17) ... ok (15ms)
+        rejectsPromise(17)
+//=> Promise.reject(Error(17)) ... ok (9ms)
+      rejectsPromise ... ok (18ms)
+    spec/returns-promise.js ... ok (37ms)
+  Functions returning a Promise can be tested like a regular function ... ok (42ms)
+  Functions throwing an Error can be tested by expecting a thrown Error ...
+    spec/expect-error.js ...
+      throws ...
+        throws(4711)
+//=> throw new Error(4711) ... ok (26ms)
+      throws ... ok (26ms)
+    spec/expect-error.js ... ok (31ms)
+  Functions throwing an Error can be tested by expecting a thrown Error ... ok (36ms)
+  Generator functions can be tested in different ways  ...
+    spec/generator-function.js ...
+      generateValues ...
+        generateValues(["foo", "bar", "baz"]).next()
+// Call .next() immediately to check the first value
+//=> {
+  value: "foo",
+  done: false
+} ... ok (62ms)
+        Array.from(generateValues([42, 17]))
+// Consume the iterator into an array, and test that
+//=> [42, 17] ... ok (54ms)
+        // Assign the iterator to a variable and iterate as many steps as needed
+const it = generateValues(["baz", "qux"]);
+it.next();
+it.next();
+it.next();
+//=> {
+  value: undefined,
+  done: true
+} ... ok (47ms)
+      generateValues ... ok (63ms)
+      fibonacci ...
+        fibonacci().next().value
+//=> 0 ... ok (39ms)
+        const f = fibonacci();
+f.next();
+f.next().value
+//=> 1 ... ok (32ms)
+        const f = fibonacci();
+f.next();
+f.next();
+f.next().value
+//=> 1 ... ok (25ms)
+        const f = fibonacci();
+[...Array(13)].map(() => f.next().value)
+//=> [0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144] ... ok (18ms)
+        const f = fibonacci([8, 13]);
+[...Array(13)].map(() => f.next().value)
+//=> [8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584] ... ok (10ms)
+      fibonacci ... ok (39ms)
+    spec/generator-function.js ... ok (70ms)
+  Generator functions can be tested in different ways  ... ok (76ms)
+  Examples without a result are not tested ...
+    spec/example-without-result.js ... ok (4ms)
+  Examples without a result are not tested ... ok (8ms)
+  Sample passing module (@supabase/doctest-js) ...
+    spec/sample-passing-module.js ...
+      titleize ...
+        titleize('wOaH')
+//=> 'Woah' ... ok (80ms)
+        titleize('w')
+//=> 'W' ... ok (70ms)
+      titleize ... ok (81ms)
+      stringData ...
+        stringData(
+  'woah'
+)
+//=> {
+  length: 4,
+  vowels: 2,
+  consonants: 2
+} ... ok (62ms)
+      stringData ... ok (62ms)
+      split ...
+        split('why am i doing this?', ' ')
+//=> [ 'why', 'am', 'i', 'doing', 'this?' ] ... ok (54ms)
+      split ... ok (54ms)
+      add ...
+        add(1, 2)
+//=> 3 ... ok (45ms)
+        add(3, 4)
+//=> 7 ... ok (38ms)
+        add(3, 4)
+//=> 7 ... ok (30ms)
+      add ... ok (45ms)
+      objectToQueryString ...
+        objectToQueryString({
+ param1: 'hello',
+ param2: 'world'
+})
+//=> 'param1=hello&param2=world' ... ok (23ms)
+      objectToQueryString ... ok (23ms)
+      convertColumn ...
+        convertColumn(
+ 'age',
+ [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}],
+ ['Paul', '33'],
+ []
+)
+//=> 33 ... ok (15ms)
+        convertColumn(
+ 'age',
+ [{name: 'first_name', type: 'text'}, {name: 'age', type: 'int4'}],
+ ['Paul', '33'],
+ ['int4']
+)
+//=> '33' ... ok (10ms)
+      convertColumn ... ok (17ms)
+    spec/sample-passing-module.js ... ok (90ms)
+  Sample passing module (@supabase/doctest-js) ... ok (97ms)
+  Sample passing class (@supabase/doctest-js) ...
+    spec/sample-passing-class.js ...
+      add ...
+        new Arithmetic().add(1, 2)
+//=> 3 ... ok (39ms)
+        const arithmetic = new Arithmetic();
+arithmetic.add(1, 9)
+//=> 10 ... ok (31ms)
+      add ... ok (39ms)
+      subtract ...
+        new Arithmetic().subtract(10, 2)
+//=> 8 ... ok (23ms)
+      subtract ... ok (23ms)
+      addToThis ...
+        new Arithmetic(7).addToThis(3)
+//=> 10 ... ok (15ms)
+      addToThis ... ok (15ms)
+      increaseThis ...
+        const arithmetic = new Arithmetic(17);
+arithmetic.increaseThis(42);
+arithmetic.foo
+//=> 59 ... ok (9ms)
+      increaseThis ... ok (9ms)
+    spec/sample-passing-class.js ... ok (45ms)
+  Sample passing class (@supabase/doctest-js) ... ok (52ms)
+Specification ... ok (316ms)
+
+ok | 2 passed (59 steps) | 0 failed | 0 ignored (1 step) (850ms)
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Where {VERSION} should be substituted with the specific version you want to use.
 
 3. Run `deno test` and relax. Your code _and_ your examples are tested!
 
-```
+```bash
 $ deno test
 
   Tests

--- a/mod.js
+++ b/mod.js
@@ -6,12 +6,12 @@ import { getTests, runExample } from "./lib.js";
  * The main entry point. Call it with the path to the file to test, and run it
  * using Deno.test().
  *
- * @param {Deno.TestContext} t
  * @param {string} file
- * @example Deno.test("doctest", (t) => doctest(t, "lib.js"));
+ * @returns {(t: Deno.TestContext) => Promise<void>}
+ * @example Deno.test("doctest", doctest("lib.js");
  * //=> undefined
  */
-export async function doctest(t, file) {
+export const doctest = (file) => async (t) => {
   const url = toFileUrl(resolve(Deno.cwd(), file));
   const nodes = await doc(url.href);
 
@@ -19,7 +19,7 @@ export async function doctest(t, file) {
     // @ts-ignore that getTests promises resolve with a boolean
     Promise.all(
       getTests(nodes).map(({ functionName, examples }) =>
-        // @ts-ignore that t.step resolve with a boolean
+        // @ts-ignore that t.step promises resolve with a boolean
         t.step({
           name: functionName,
           fn: (t) =>

--- a/mod.js
+++ b/mod.js
@@ -33,4 +33,4 @@ export const doctest = (file) => async (t) => {
         })
       ),
     ));
-}
+};

--- a/test.js
+++ b/test.js
@@ -4,34 +4,34 @@ Deno.test("Doctest", async (t) => {
   await t.step({
     name: "mod",
     ignore: true,
-    fn: (t) => doctest(t, "mod.js"),
+    fn: doctest("mod.js"),
   });
-  await doctest(t, "lib.js");
+  await doctest("lib.js")(t);
 });
 
 Deno.test("Specification", async (t) => {
   await t.step(
     "Functions returning a Promise can be tested like a regular function",
-    (t) => doctest(t, "spec/returns-promise.js"),
+    doctest("spec/returns-promise.js"),
   );
   await t.step(
     "Functions throwing an Error can be tested by expecting a thrown Error",
-    (t) => doctest(t, "spec/expect-error.js"),
+    doctest("spec/expect-error.js"),
   );
   await t.step(
     "Generator functions can be tested in different ways ",
-    (t) => doctest(t, "spec/generator-function.js"),
+    doctest("spec/generator-function.js"),
   );
   await t.step(
     "Examples without a result are not tested",
-    (t) => doctest(t, "spec/example-without-result.js"),
+    doctest("spec/example-without-result.js"),
   );
   await t.step(
     "Sample passing module (@supabase/doctest-js)",
-    (t) => doctest(t, "spec/sample-passing-module.js"),
+    doctest("spec/sample-passing-module.js"),
   );
   await t.step(
     "Sample passing class (@supabase/doctest-js)",
-    (t) => doctest(t, "spec/sample-passing-class.js"),
+    doctest("spec/sample-passing-class.js"),
   );
 });


### PR DESCRIPTION
- Instead of taking the `t` test context as a parameter, take just the file name and return a function taking the test context to simplify usage.
- Update README with the full spec output